### PR TITLE
Support for kafka-clients 3.0 and spring-kafka 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,12 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>2.8.0</version>
+                <version>3.0.0</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.kafka</groupId>
                 <artifactId>spring-kafka</artifactId>
-                <version>2.7.6</version>
+                <version>2.8.0</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup</groupId>


### PR DESCRIPTION
Version 2.8 introduces the new interface CommonErrorHandler
https://docs.spring.io/spring-kafka/reference/html/#x28-eh