### PR TITLE
Updated Kafka and other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -107,12 +107,12 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.3</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.kafka</groupId>
                 <artifactId>spring-kafka</artifactId>
-                <version>2.8.0</version>
+                <version>2.9.2</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup</groupId>
@@ -122,7 +122,7 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.4.0</version>
+                <version>5.9.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -201,7 +201,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.4.1</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>


### PR DESCRIPTION
Before updating common-kafka, I'd like to update kobuka to the latest versions of 
- kafka clients 3.2
- spring kakfa 2.9

I have also updated other dependencies, even if not strictly needed.
If this PR is fine, shall we release version 1.2.0 of kobuka?
