### PR TITLE
Upgrade maven-gpg-plugin to v3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <jgitflow-maven-plugin.version>1.0-m5.1</jgitflow-maven-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>


### PR DESCRIPTION
The build on master https://app.travis-ci.com/github/swisspush/kobuka/builds/259576770
fails because maven-gpg-plugin is no longer able to sign the artifacts.
According to some posts on StackOverflow, upgrading the plugin from 1.6 (Jan 2015) to 3.0.1 (latest - May 2021) would fix the problem.