### PR TITLE
Fixes in the generated sources and javadoc

### DIFF
--- a/kobuka-gen/src/main/java/org/swisspush/kobuka/gen/Generator.java
+++ b/kobuka-gen/src/main/java/org/swisspush/kobuka/gen/Generator.java
@@ -150,26 +150,17 @@ public class Generator {
     }
 
     private static TypeName resolveType(ConfigDef.Type type) {
-        switch (type) {
-            case INT:
-                return ClassName.get(Integer.class);
-            case BOOLEAN:
-                return ClassName.get(Boolean.class);
-            case CLASS:
-                return ClassName.get(Class.class);
-            case DOUBLE:
-                return ClassName.get(Double.class);
-            case LONG:
-                return ClassName.get(Long.class);
-            case SHORT:
-                return ClassName.get(Short.class);
-            case LIST:
-                return ParameterizedTypeName.get(List.class, String.class);
-            case PASSWORD:
-                return ClassName.get(Password.class);
-            default:
-                return ClassName.get(String.class);
-        }
+        return switch (type) {
+            case INT -> ClassName.get(Integer.class);
+            case BOOLEAN -> ClassName.get(Boolean.class);
+            case CLASS -> ClassName.get(Class.class);
+            case DOUBLE -> ClassName.get(Double.class);
+            case LONG -> ClassName.get(Long.class);
+            case SHORT -> ClassName.get(Short.class);
+            case LIST -> ParameterizedTypeName.get(List.class, String.class);
+            case PASSWORD -> ClassName.get(Password.class);
+            default -> ClassName.get(String.class);
+        };
     }
 
     private static String renderDefault(ConfigDef.ConfigKey key) {
@@ -203,18 +194,13 @@ public class Generator {
                 break;
             }
         }
-        switch (i) {
-            case 1:
-                return " (" + value + " kibibyte" + (value == 1 ? ")" : "s)");
-            case 2:
-                return " (" + value + " mebibyte" + (value == 1 ? ")" : "s)");
-            case 3:
-                return " (" + value + " gibibyte" + (value == 1 ? ")" : "s)");
-            case 4:
-                return " (" + value + " tebibyte" + (value == 1 ? ")" : "s)");
-            default:
-                return "";
-        }
+        return switch (i) {
+            case 1 -> " (" + value + " kibibyte" + (value == 1 ? ")" : "s)");
+            case 2 -> " (" + value + " mebibyte" + (value == 1 ? ")" : "s)");
+            case 3 -> " (" + value + " gibibyte" + (value == 1 ? ")" : "s)");
+            case 4 -> " (" + value + " tebibyte" + (value == 1 ? ")" : "s)");
+            default -> "";
+        };
     }
 
     private static String niceTimeUnits(long millis) {

--- a/kobuka-gen/src/main/java/org/swisspush/kobuka/gen/Generator.java
+++ b/kobuka-gen/src/main/java/org/swisspush/kobuka/gen/Generator.java
@@ -120,12 +120,21 @@ public class Generator {
     private static void generateMethod(TypeSpec.Builder interfaceBuilder, TypeSpec.Builder classBuilder, ConfigDef.ConfigKey key, TypeName type) {
         interfaceBuilder.addMethod(methodBuilder(toCamelCase(key.displayName))
                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
+
+                /*
+                    The JavaDoc in kafka-clients contains html errors (e.g. 'self-closing element not allowed')
+                    which cause a failure in the build of maven-javadoc-plugin.
+                    Since the source code of kafka-clients is not under our control, 'failOnError' configuration is set
+                    to 'false'
+
+                    See: https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#failOnError
+                 */
                 .addJavadoc(
-                        "<b>" + key.displayName + "</b><p>\n" +
-                                key.documentation.replaceAll("\\. ", ".<p>") +
-                                "\n<p><b>Default:</b> " + renderDefault(key) +
-                                "\n<p><b>Valid Values:</b> " + (key.validator != null ? key.validator.toString() : "") +
-                                "\n<p><b>Importance:</b> " + key.importance.toString().toLowerCase(Locale.ROOT))
+                        "<p><b>" + key.displayName + "</b></p>\n" +
+                                key.documentation.replaceAll("\\. ", ".<br>") +
+                                "\n<p><b>Default:</b> " + renderDefault(key) + "</p>" +
+                                "\n<p><b>Valid Values:</b> " + (key.validator != null ? key.validator.toString() : "") + "</p>" +
+                                "\n<p><b>Importance:</b> " + key.importance.toString().toLowerCase(Locale.ROOT) + "</p>")
 
                 .returns(TypeVariableName.get("T"))
                 .addParameter(type, "value")

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,7 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <failOnError>false</failOnError>
                             <source>${java.version}</source>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
The failure on the master branch is caused by errors thrown by the maven-javadoc-plugin.

These errors were already present in release 1.3.0, but it at warning level, not enough to fail the build.

See here the error in Release 1.3.0
https://app.travis-ci.com/github/swisspush/kobuka/builds/259229161#L3690
_[WARNING] javadoc: warning - No source files for package org.swisspush.kobuka.client.base.AdminClientConfigFields.java.org.swisspush.kobuka.client.base_

and here the same problem (error level) in Release 1.4.0
https://app.travis-ci.com/github/swisspush/kobuka/builds/259667969#L3407
_[ERROR] error: No source files for package org.swisspush.kobuka.client.base.ProducerConfigFields.java.org.swisspush.kobuka.client.base_

**Change #1: fixed the path of the generated sources in the Generator**
As shown in this screenshot, the generated sources were created in the wrong folder: _\target\generated-sources\kobuka\org\swisspush\kobuka\client\base\AbstractConsumerConfigBuilder.java\org\swisspush\kobuka\client\base_
![image](https://user-images.githubusercontent.com/11211750/212654131-f8891556-2ddc-4024-84bb-4cf1dd73e81e.png)
this was fixed in https://github.com/swisspush/kobuka/commit/0f23c3349f885dd13d8660f8e40d05e11cfdc416

After this fix, the classes are added to the 'base' folder:
![image](https://user-images.githubusercontent.com/11211750/212655083-6adf1aea-f2d0-4c59-b556-4ce3d3cc241e.png)

**Change #2: prevent maven-javadoc-plugin to fail if the generated JavaDoc is incorrect**
As reported in the comment added in  commit https://github.com/swisspush/kobuka/commit/9b07018811c0bb019f97ca21f2149dbf8fd7bbf7 , some JavaDoc in kafka-clients is invalid and makes the build fail. Since it's quite hard to find a workaround for every HTML error in kafka-clients, it's probably better to ignore them.
